### PR TITLE
Keep inline comments on same line

### DIFF
--- a/lib/rubocop/cask/ast/cask_block.rb
+++ b/lib/rubocop/cask/ast/cask_block.rb
@@ -58,7 +58,9 @@ module RuboCop
         end
 
         def stanza_comments(stanza_node)
-          comments_hash[stanza_node.loc]
+          stanza_node.each_node.reduce([]) do |comments, node|
+            comments | comments_hash[node.loc]
+          end
         end
 
         def comments_hash

--- a/spec/rubocop/cop/cask/stanza_order_spec.rb
+++ b/spec/rubocop/cop/cask/stanza_order_spec.rb
@@ -157,7 +157,7 @@ describe RuboCop::Cop::Cask::StanzaOrder do
           postflight do
             puts 'We have liftoff!'
           end
-          sha256 :no_check
+          sha256 :no_check # comment on same line
         end
       CASK
     end
@@ -165,7 +165,7 @@ describe RuboCop::Cop::Cask::StanzaOrder do
       <<-CASK.undent
         cask 'foo' do
           version :latest
-          sha256 :no_check
+          sha256 :no_check # comment on same line
           # comment with an empty line between
 
           # comment directly above


### PR DESCRIPTION
Fixes bug where comments on the same line as a stanza would not be moved when the stanza was reordered.