### PR TITLE
Add settings for default cops

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,7 @@
+###
+### RuboCop Cask cops
+###
+
 Cask/NoDslVersion:
   Description: 'Do not use the deprecated DSL version syntax in your cask header.'
   Enabled: true
@@ -9,3 +13,56 @@ Cask/StanzaGrouping:
 Cask/StanzaOrder:
   Description: 'Ensure that cask stanzas are sorted correctly. More info at https://github.com/caskroom/homebrew-cask/blob/master/CONTRIBUTING.md#stanza-order'
   Enabled: true
+
+###
+### RuboCop cops
+###
+
+Metrics/LineLength:
+  Enabled: false
+
+Performance/StringReplacement:
+  Enabled: false
+
+Style/AlignHash:
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
+
+Style/BarePercentLiterals:
+  EnforcedStyle: percent_q
+
+Style/Documentation:
+  Enabled: false
+
+Style/EmptyElse:
+  Enabled: false
+
+Style/FileName:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedStyle: ruby19_no_mixed_keys
+
+Style/IndentArray:
+  EnforcedStyle: align_brackets
+
+Style/IndentHash:
+  EnforcedStyle: align_braces
+
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%':  '{}'
+    '%i': '{}'
+    '%q': '{}'
+    '%Q': '{}'
+    '%r': '{}'
+    '%s': '()'
+    '%w': '[]'
+    '%W': '[]'
+    '%x': '()'
+
+Style/RegexpLiteral:
+  EnforcedStyle: percent_r
+
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -15,8 +15,12 @@ describe 'RuboCop Project' do
       RuboCop::ConfigLoader.load_file('config/default.yml')
     end
 
+    let(:cask_config_keys) do
+      default_config.keys.select { |k| k.start_with?('Cask/') }
+    end
+
     it 'has configuration for all cops' do
-      expect(default_config.keys.sort).to eq(cop_names.sort)
+      expect(cask_config_keys.sort).to eq(cop_names.sort)
     end
 
     it 'has a nicely formatted description for all cops' do


### PR DESCRIPTION
This way, Cask taps can just use the following for `.rubocop.yml`:

```yml
require: rubocop-cask
```