### PR TITLE
Update rubocop dependency to 0.43.0.

### DIFF
--- a/rubocop-cask.gemspec
+++ b/rubocop-cask.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['MIT-LICENSE.md', 'README.md']
 
   s.add_dependency 'public_suffix', '~> 2.0'
-  s.add_dependency 'rubocop', '~> 0.42.0'
+  s.add_dependency 'rubocop', '~> 0.43.0'
 
   s.add_development_dependency 'bundler', '~> 1.3'
 end


### PR DESCRIPTION
Homebrew is using 0.43.0 now.