### PR TITLE
HomepageMatchesUrl: skip if no homepage stanza

### DIFF
--- a/lib/rubocop/cop/cask/homepage_matches_url.rb
+++ b/lib/rubocop/cop/cask/homepage_matches_url.rb
@@ -8,7 +8,7 @@ module RuboCop
       # or if it doesn't, checks if a comment in the form
       # `# example.com was verified as official when first introduced to the cask`
       # is present.
-      class HomepageMatchesUrl < Cop
+      class HomepageMatchesUrl < Cop # rubocop:disable Metrics/ClassLength
         extend Forwardable
         include CaskHelp
 
@@ -29,6 +29,7 @@ module RuboCop
 
         def on_cask(cask_block)
           @cask_block = cask_block
+          return unless homepage_stanza
           add_offenses
         end
 
@@ -133,7 +134,11 @@ module RuboCop
         end
 
         def homepage
-          PublicSuffix.domain(domain(toplevel_stanzas.find(&:homepage?)))
+          PublicSuffix.domain(domain(homepage_stanza))
+        end
+
+        def homepage_stanza
+          toplevel_stanzas.find(&:homepage?)
         end
       end
     end

--- a/spec/rubocop/cop/cask/homepage_matches_url_spec.rb
+++ b/spec/rubocop/cop/cask/homepage_matches_url_spec.rb
@@ -196,4 +196,16 @@ describe RuboCop::Cop::Cask::HomepageMatchesUrl do
       include_examples 'reports offenses'
     end
   end
+
+  context 'when there is no homepage' do
+    let(:source) do
+      <<-CASK.undent
+        cask 'foo' do
+          url 'https://example.com/foo.zip'
+        end
+      CASK
+    end
+
+    include_examples 'does not report any offenses'
+  end
 end


### PR DESCRIPTION
Fix errors like this:

```
$ brew cask style --fix Casks/font-source-han-sans.rb
An error occurred while Cask/HomepageMatchesUrl cop was inspecting /usr/local/Homebrew/Library/Taps/caskroom/homebrew-fonts/Casks/font-source-han-sans.rb.
To see the complete backtrace run rubocop -d.
== Casks/font-source-han-sans.rb ==
C:  6:  3: [Corrected] homepage stanza out of order
C:  6:  8: [Corrected] Prefer single-quoted strings when you don't need string interpolation or special symbols.
C:  7:  3: [Corrected] name stanza out of order
C:  7:  8: [Corrected] Prefer single-quoted strings when you don't need string interpolation or special symbols.

1 file inspected, 4 offenses detected, 4 offenses corrected

1 error occurred:
An error occurred while Cask/HomepageMatchesUrl cop was inspecting /usr/local/Homebrew/Library/Taps/caskroom/homebrew-fonts/Casks/font-source-han-sans.rb.
```